### PR TITLE
Add external write-ups to Boston Key Party 2017

### DIFF
--- a/boston-key-party-2017/README.md
+++ b/boston-key-party-2017/README.md
@@ -1,6 +1,6 @@
 # Boston Key Party CTF 2017 write-ups
 
-* <TODO>
+* (TODO)
 * [Scoreboard](TODO) or [local alternative](TODOLOCAL)
 
 ## Completed write-ups
@@ -9,23 +9,26 @@
 
 ## External write-ups only
 
+* [pwn/solitary-confinement-99](pwn/solitary-confinement-99)
+* [pwn/vimjail-150](pwn/vimjail-150)
+* [pwn/signed-shell-server-200](pwn/signed-shell-server-200)
+* [pwn/hiddensc-200](pwn/hiddensc-200)
+* [pwn/memo-300](pwn/memo-300)
 * [pwn/barewithme-750](pwn/barewithme-750)
 * [crypto/rsa-buffet-150](crypto/rsa-buffet-150)
 * [crypto/sponge-200](crypto/sponge-200)
 * [crypto/multi-party-computation-250](crypto/multi-party-computation-250)
 * [crypto/minesweeper-350](crypto/minesweeper-350)
 * [crypto/sidh-rsa-aes128-gcm-sha256-600](crypto/sidh-rsa-aes128-gcm-sha256-600)
+* [cloud/prudentialv2-50](cloud/prudentialv2-50)
+* [cloud/artisinal-shoutboxes-200](cloud/artisinal-shoutboxes-200)
+* [cloud/qt-crackme-250](cloud/qt-crackme-250)
+* [cloud/accelerated-zone-250](cloud/accelerated-zone-250)
+* [cloud/slow-450](cloud/slow-450)
 
 ## Missing write-ups
 
-* [pwn/vimjail-150](pwn/vimjail-150)
-* [pwn/signed-shell-server-200](pwn/signed-shell-server-200)
-* [pwn/hiddensc-200](pwn/hiddensc-200)
-* [pwn/memo-300](pwn/memo-300)
 * [cloud/sanity-check-1](cloud/sanity-check-1)
-* [cloud/prudentialv2-50](cloud/prudentialv2-50)
 * [cloud/wackusensor-100](cloud/wackusensor-100)
 * [cloud/beat-in-a-box-150](cloud/beat-in-a-box-150)
-* [cloud/qt-crackme-250](cloud/qt-crackme-250)
-* [cloud/accelerated-zone-250](cloud/accelerated-zone-250)
 * [cloud/supercomputer-450](cloud/supercomputer-450)

--- a/boston-key-party-2017/cloud/accelerated-zone-250/README.md
+++ b/boston-key-party-2017/cloud/accelerated-zone-250/README.md
@@ -17,4 +17,4 @@
 
 ## Other write-ups and resources
 
-* none yet
+* <https://jiulongw.github.io/post/boston-key-party-2017-accelerated-zone/>

--- a/boston-key-party-2017/cloud/artisinal-shoutboxes-200/README.md
+++ b/boston-key-party-2017/cloud/artisinal-shoutboxes-200/README.md
@@ -1,0 +1,17 @@
+# Boston Key Party CTF 2017: artisinal-shoutboxes-200
+
+**Category:** Cloud
+**Points:** 200
+**Solves:**
+**Description:**
+
+> (missing description)
+
+## Write-up
+
+(TODO)
+
+## Other write-ups and resources
+
+* <https://github.com/p4-team/ctf/blob/master/2017-02-25-bkp/cloud_200_artisinal_shoutboxes/README.md>
+* <http://www.rogdham.net/2017/02/27/boston-key-party-2017-write-ups.en>

--- a/boston-key-party-2017/cloud/prudentialv2-50/README.md
+++ b/boston-key-party-2017/cloud/prudentialv2-50/README.md
@@ -15,4 +15,10 @@
 
 ## Other write-ups and resources
 
-* none yet
+* <https://github.com/bl4de/ctf/blob/master/2017/BostonKeyParty_2017/Prudentialv2/Prudentialv2_Cloud_50.md>
+* <http://www.rogdham.net/2017/02/27/boston-key-party-2017-write-ups.en>
+* <http://rotimiakinyele.com/shattering-sha1-to-solve-the-bostonkeyparty-ctf-challenge.jsp>
+* <https://0xd13a.github.io/ctfs/bkp2017/prudentialv2/>
+* <https://github.com/R3dCr3sc3nt/BostonKeyParty2017/blob/master/cloud/Prudentialv2/README.md#readme>
+* <https://l4ser.github.io/bkp2017prudentialv2/>
+* <https://chc.cs.cornell.edu/writeups/6/>

--- a/boston-key-party-2017/cloud/qt-crackme-250/README.md
+++ b/boston-key-party-2017/cloud/qt-crackme-250/README.md
@@ -15,4 +15,4 @@
 
 ## Other write-ups and resources
 
-* none yet
+* <https://r2s4x.github.io/writeup/2017/03/01/boston-key-party-ctf-2017-qt-crackme-writeup.html>

--- a/boston-key-party-2017/cloud/slow-450/README.md
+++ b/boston-key-party-2017/cloud/slow-450/README.md
@@ -1,0 +1,16 @@
+# Boston Key Party CTF 2017: slow-450
+
+**Category:** Cloud
+**Points:** 450
+**Solves:**
+**Description:**
+
+> (missing description)
+
+## Write-up
+
+(TODO)
+
+## Other write-ups and resources
+
+* <https://github.com/p4-team/ctf/tree/master/2017-02-25-bkp/slow>

--- a/boston-key-party-2017/crypto/rsa-buffet-150/README.md
+++ b/boston-key-party-2017/crypto/rsa-buffet-150/README.md
@@ -20,3 +20,6 @@
 * [Hackeriet](http://blog.hackeriet.no/eating-a-rsa-buffet/)
 * [Capture the Swag](https://ctf.rip/bkp2017-rsabuffet/)
 * https://gist.github.com/elliptic-shiho/5fb8e9b74abb90639def7d919dad08a9
+* <https://github.com/p4-team/ctf/tree/master/2017-02-25-bkp/rsa_buffet>
+* <https://github.com/R3dCr3sc3nt/BostonKeyParty2017/blob/master/crypto/rsa-buffet/README.md>
+* <https://chc.cs.cornell.edu/writeups/6/>

--- a/boston-key-party-2017/crypto/sponge-200/README.md
+++ b/boston-key-party-2017/crypto/sponge-200/README.md
@@ -22,3 +22,4 @@
 * [greunion](http://www.rogdham.net/2017/02/27/boston-key-party-2017-write-ups.en)
 * [p4](https://github.com/p4-team/ctf/tree/master/2017-02-25-bkp/sponge)
 * https://gist.github.com/elliptic-shiho/e06d961508b0e32ecd942179926e7197
+* <https://chc.cs.cornell.edu/writeups/6/>

--- a/boston-key-party-2017/pwn/barewithme-750/README.md
+++ b/boston-key-party-2017/pwn/barewithme-750/README.md
@@ -17,3 +17,4 @@
 ## Other write-ups and resources
 
 * [jeffball](https://github.com/jeffball55/ctf_writeups/tree/master/boston_key_party_2017/barewithme)
+* <https://github.com/esanfelix/writeup/tree/master/bkpctf2017-barewithme>

--- a/boston-key-party-2017/pwn/hiddensc-200/README.md
+++ b/boston-key-party-2017/pwn/hiddensc-200/README.md
@@ -22,4 +22,5 @@
 
 ## Other write-ups and resources
 
-* none yet
+* <http://pwning.re/2017/02/27/bkp-hidden-sc/>
+* <https://github.com/sebel1010/ctf-writeups/blob/master/2017/boston-key-party/hiddensc.md>

--- a/boston-key-party-2017/pwn/memo-300/README.md
+++ b/boston-key-party-2017/pwn/memo-300/README.md
@@ -19,3 +19,8 @@
 ## Other write-ups and resources
 
 * <https://bannsecurity.com/index.php/home/10-ctf-writeups/40-boston-key-party-2017-memo>
+* <https://github.com/irGeeks/ctf/tree/master/2017-BostonKeyParty/memo>
+* <https://www.amn3s1a.com/blog/writeup/2017/02/25/Boston-Key-Party-CTF-Memo.html>
+* <https://www.youtube.com/watch?v=oONwOfA_oMo>
+* <https://github.com/DMArens/CTF-Writeups/tree/master/2017/BostonKeyParty/memo-exploit300>
+* <https://bannsecurity.com/index.php/home/10-ctf-writeups/40-boston-key-party-2017-memo>

--- a/boston-key-party-2017/pwn/signed-shell-server-200/README.md
+++ b/boston-key-party-2017/pwn/signed-shell-server-200/README.md
@@ -21,4 +21,6 @@
 
 ## Other write-ups and resources
 
-* none yet
+* <https://losfuzzys.github.io/writeup/2017/02/27/bkpctf2017-signed-shell-server/>
+* <https://github.com/p4-team/ctf/tree/master/2017-02-25-bkp/signed_shell_server>
+* <https://chc.cs.cornell.edu/writeups/6/>

--- a/boston-key-party-2017/pwn/solitary-confinement-99/README.md
+++ b/boston-key-party-2017/pwn/solitary-confinement-99/README.md
@@ -1,0 +1,17 @@
+# Boston Key Party CTF 2017: solitary-confinement-99
+
+**Category:** Pwn
+**Points:** 99
+**Solves:**
+**Description:**
+
+> (missing description)
+
+## Write-up
+
+(TODO)
+
+## Other write-ups and resources
+
+* <https://losfuzzys.github.io/writeup/2017/02/27/bkpctf2017-solitary-confinement/>
+* <https://david942j.blogspot.kr/2017/03/write-up-boston-key-party-2017-pwn99.html>

--- a/boston-key-party-2017/pwn/vimjail-150/README.md
+++ b/boston-key-party-2017/pwn/vimjail-150/README.md
@@ -20,4 +20,8 @@
 
 ## Other write-ups and resources
 
-* none yet
+* <https://ctftime.org/writeup/5784>
+* <https://github.com/xPowerz/CTF-Writeups/tree/master/2017/BKP/vimjail>
+* <https://github.com/p4-team/ctf/tree/master/2017-02-25-bkp/vimjail>
+* <https://yous.be/2017/03/01/boston-key-party-ctf-2017-vimjail-write-up/>
+* <https://team-nawhack.fr/2017/02/26/bkp-2017-vimjail/>


### PR DESCRIPTION
Also, additional problems are added:

- pwn/solitary-confinement-99
- cloud/artisinal-shoutboxes-200
- cloud/slow-450